### PR TITLE
Ugly hack for weird runtimes

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -60,7 +60,7 @@ function love.run()
 			if e == "quit" then
 				if not love.quit() then
 					love.audio.stop()
-					return
+					return function() return a or 0 end
 				end
 			end
 			love.handlers[e](a,b,c,d)


### PR DESCRIPTION
Some environments (such as [this abomination](https://github.com/Hyperboid/kristal-loveloader)) rely on love.run returning a function, like the built-in one. We can't do what you're supposed to do since that breaks legacy LÖVE support.